### PR TITLE
ease dependency on a specific version of urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 -e .
-urllib3
+urllib3>=1.2,<2.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read(fname):
     except IOError:
         return ""
 
-requirements =      ['urllib3==1.7.1']
+requirements =      ['urllib3>=1.2,<2.0']
 test_requirements = ['pytest',
                      'pytest-cov']
 


### PR DESCRIPTION
as a 3rd party module, we really shouldn't be so specific about what version of urllib3 we depend on.

verson 1.2 added python 3 support, so that's as low as we can go.
having a loose dependency to be below 2.0 should keep us testing against the latest urllb3 on Travis.
