### PR TITLE
avoid UnicodeEncodeError by encoding query_dict values

### DIFF
--- a/KISSmetrics/query_string.py
+++ b/KISSmetrics/query_string.py
@@ -14,6 +14,32 @@ except ImportError:
     from urllib.parse import urlencode
 
 
+def encode_object(obj):
+    """
+    Encode iterable values with UTF8,
+    to avoid UnicodeEncodeError thrown by urlencode.
+
+    :param obj: dict, list or tuple
+    :returns: new object with UTF8-encoded values
+    :rtype: iterable
+    """
+    def _encode_value(value):
+        if isinstance(value, unicode):
+            return value.encode('utf8')
+        if isinstance(value, str):
+            # Must be encoded in UTF-8
+            return value.decode('utf8')
+        return value
+
+    if isinstance(obj, dict):
+        return {k: _encode_value(v) for k, v in obj.iteritems()}
+
+    # list or tuple (not string or dict)
+    if hasattr(obj, '__iter__'):
+        return [_encode_value(v) for v in obj]
+    return obj
+
+
 def create_query(key, person, event=None, timestamp=None,
                  identity=None, properties=None):
     """Build and encode query string.
@@ -49,4 +75,4 @@ def create_query(key, person, event=None, timestamp=None,
     if identity:
         query_dict[ALIAS_KEY] = identity
     query_dict.update(properties)
-    return urlencode(query_dict)
+    return urlencode(encode_object(query_dict))

--- a/KISSmetrics/query_string.py
+++ b/KISSmetrics/query_string.py
@@ -32,7 +32,7 @@ def encode_object(obj):
         return value
 
     if isinstance(obj, dict):
-        return {k: _encode_value(v) for k, v in obj.iteritems()}
+        return {_encode_value(k): _encode_value(v) for k, v in obj.items()}
 
     # list or tuple (not string or dict)
     if hasattr(obj, '__iter__'):

--- a/KISSmetrics/tests/test_kissmetrics.py
+++ b/KISSmetrics/tests/test_kissmetrics.py
@@ -82,6 +82,18 @@ class KISSmetricsRequestTestCase(unittest.TestCase):
         assert parse_qs(query)['_p'] == ['bar']
         assert parse_qs(query)['_n'] == ['fizzed']
 
+    def test_event_unicode(self):
+        properties = {'fn': u'Róbert', u'foó': u'Rafa\u0142'}
+        data = {'event': u'informação', 'properties': properties}
+        query = KISSmetrics.query_string.create_query(key='foo', person='bar', **data)
+        assert parse_qs(query)['_k'] == ['foo']
+        assert parse_qs(query)['_p'] == ['bar']
+        # compare as str
+        assert parse_qs(query)['fn'] == [properties['fn'].encode('utf8')]
+        assert parse_qs(query)[u'foó'.encode('utf8')] == [properties[u'foó'].encode('utf8')]
+        # compare as unicode
+        assert parse_qs(query)['_n'][0].decode('utf8') == u'informação'
+
     def test_set(self):
         properties = {'cool': '1'}
         query = KISSmetrics.query_string.create_query(key='foo', person='bar', properties=properties)


### PR DESCRIPTION
urlencode throws UnicodeEncodeError when query_dict contains unicode values

E.g. I got this error with an event that contained a name with an apostrophe:

```
  File "/home/zazzy/zazzy.co/apps/tasks/order.py", line 34, in record
    return KM.record(email, what, data)
  File "/home/zazzy/supervisor/.venv/local/lib/python2.7/site-packages/KISSmetrics/client.py", line 52, in record
    host=self.trk_host, path=path)
  File "/home/zazzy/supervisor/.venv/local/lib/python2.7/site-packages/KISSmetrics/request.py", line 23, in record
    properties=properties)
  File "/home/zazzy/supervisor/.venv/local/lib/python2.7/site-packages/KISSmetrics/query_string.py", line 52, in create_query
    return urlencode(query_dict)
  File "/usr/lib/python2.7/urllib.py", line 1332, in urlencode
    v = quote_plus(str(v))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf3' in position 1: ordinal not in range(128)
```

Here's an old related issue https://github.com/kissmetrics/KISSmetrics/issues/6

These changes do not seem to break any tests, encoded values show up in KM webapp without problem. Could you please take a look and consider merging them in?